### PR TITLE
🆙 deno を v2.1.4 にアップグレード

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,16 +7,19 @@ on:
   pull_request:
 
 jobs:
-  check:
-    uses: kakomimasu/kakomimasu.github.io/.github/workflows/dfl-check.yml@main
   test:
-    needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: denoland/setup-deno@v1
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.43.1
+          deno-version: v2.1.4
+      - name: Run fmt
+        run: |
+          deno fmt --check
+      - name: Run lint
+        run: |
+          deno lint
       - name: Run check
         run: |
           deno task check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine-1.43.1
+FROM denoland/deno:alpine-2.1.4
 
 WORKDIR /home/sztm
 COPY . .

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "tasks": {
     "cache": "deno cache --allow-import src/main.ts",
     "check": "deno check src/main.ts",
-    "run": "deno run -A --unstable-cron --env src/main.ts",
+    "run": "deno run -A --unstable-cron --env-file=.env src/main.ts",
     "update": "deno run -A https://deno.land/x/udd/main.ts **/*.ts"
   },
   "imports": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "cache": "deno cache src/main.ts",
+    "cache": "deno cache --allow-import src/main.ts",
     "check": "deno check src/main.ts",
     "run": "deno run -A --unstable-cron --env src/main.ts",
     "update": "deno run -A https://deno.land/x/udd/main.ts **/*.ts"


### PR DESCRIPTION
ナナシス周年画像Botが動かなくなっていたためアップグレード

現時点で最新の v2.1.6 だとエラーがでてアップロードできなかったため v2.1.4 に留めた